### PR TITLE
style(theme): 增加主题设置弹窗的内边距

### DIFF
--- a/docs/.vitepress/theme/components/ThemeSettings.vue
+++ b/docs/.vitepress/theme/components/ThemeSettings.vue
@@ -814,7 +814,7 @@ onUnmounted(() => {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 8px 10px;
+  padding: 12px 16px;
 }
 
 .theme-modal-title {
@@ -845,7 +845,7 @@ onUnmounted(() => {
 }
 
 .theme-settings-content {
-  padding: 12px;
+  padding: 16px;
   max-height: calc(80vh - 80px);
   overflow-y: auto;
 }
@@ -1342,7 +1342,7 @@ onUnmounted(() => {
   }
 
   .theme-settings-content {
-    padding: 12px 12px;
+    padding: 16px;
   }
 
   .appearance-options {


### PR DESCRIPTION
Requested by @minorcell

### 修改内容

修复主题设置弹窗样式，增加适当的内边距，解决弹窗过于紧凑的问题。

### 具体更改

- 将 `.theme-modal-header` 的 padding 从 `8px 10px` 增加到 `12px 16px`
- 将 `.theme-settings-content` 的 padding 从 `12px` 增加到 `16px`
- 更新移动端响应式样式以保持一致性

### 效果

现在主题设置弹窗有了更合理的内边距：
1. **弹窗头部**: 标题和关闭按钮周围有更多空间
2. **弹窗内容区**: 各个设置选项之间有更舒适的间距
3. **移动端适配**: 确保移动设备上也有一致的体验

Closes #24